### PR TITLE
List the process definitions for a pipeline

### DIFF
--- a/lib/starfish/project_app.rb
+++ b/lib/starfish/project_app.rb
@@ -2,6 +2,7 @@ require 'sinatra/base'
 require 'starfish/authentication_helpers'
 require 'starfish/url_helpers'
 require 'starfish/not_found'
+require 'starfish/service_manifest'
 
 module Starfish
   class ProjectApp < Sinatra::Base
@@ -29,6 +30,7 @@ module Starfish
           "Channels"      => channels_path(pipeline),
           "Config"        => pipeline_config_path(pipeline),
           "Pull Requests" => pulls_path(pipeline),
+          "Processes"     => processes_path(pipeline),
           "Canaries"      => canaries_path(pipeline),
         }
 
@@ -250,6 +252,20 @@ module Starfish
       @project = $repo.find_project_by_slug(params[:project])
       @pipeline = @project.find_pipeline_by_slug(params[:pipeline])
       erb :list_canaries
+    end
+
+    get '/:project/:pipeline/processes' do
+      @project = $repo.find_project_by_slug(params[:project])
+      @pipeline = @project.find_pipeline_by_slug(params[:pipeline])
+
+      manifest = ServiceManifest.new(@project, {
+        github_token: session[:auth].credentials.token,
+        branch: @pipeline.branch
+      })
+
+      @processes = manifest.processes
+
+      erb :list_processes
     end
 
     post '/:project/pipelines' do

--- a/lib/starfish/service_manifest.rb
+++ b/lib/starfish/service_manifest.rb
@@ -1,0 +1,44 @@
+require 'json'
+require 'base64'
+
+module Starfish
+  class ServiceManifest
+    class Process
+      attr_reader :name, :command
+
+      def initialize(name:, command:)
+        @name = name
+        @command = command
+      end
+    end
+
+    def initialize(project, branch:, github_token:)
+      @project = project
+      @branch = branch
+      @github_token = github_token
+    end
+
+    def processes
+      manifest ? manifest["roles"].map {|name, data| Process.new(name: name, command: data["command"]) } : []
+    end
+
+    private
+
+    def manifest
+      @manifest ||= load_manifest
+    end
+
+    def load_manifest
+      file = github.contents(@project.repo, path: "manifest.json", ref: @branch)
+      JSON.parse(Base64.decode64(file.content))
+    rescue Octokit::NotFound
+      nil
+    end
+
+    def github
+      @github ||= Octokit::Client.new(
+        access_token: @github_token
+      )
+    end
+  end
+end

--- a/lib/starfish/url_helpers.rb
+++ b/lib/starfish/url_helpers.rb
@@ -40,6 +40,10 @@ module Starfish
       [pipeline_path(pipeline), "config"].join("/")
     end
 
+    def processes_path(pipeline)
+      [pipeline_path(pipeline), "processes"].join("/")
+    end
+
     def channels_path(pipeline)
       [pipeline_path(pipeline), "channels"].join("/")
     end

--- a/views/project/list_processes.erb
+++ b/views/project/list_processes.erb
@@ -1,0 +1,28 @@
+<%= erb :project_navigation %>
+
+<div class="panel panel-default">
+  <% if @processes.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Command</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @processes.each do |process| %>
+            <tr>
+              <th width="10"><code><%= process.name %></code></th>
+              <td><code><%= process.command %></code></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="panel-body">
+      <p>No process roles defined in the <code>manifest.json</code> file in the <code><%= @pipeline.branch %></code> branch of this project. Add this file in order to track process roles.</p>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
Reads the `manifest.json` file from the current pipeline's branch in the project and displays the process roles defined therein in a table.
